### PR TITLE
Add dllPath.bat to IOC Makefile.win32 TARGETS

### DIFF
--- a/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/Makefile.win32
+++ b/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/Makefile.win32
@@ -1,6 +1,5 @@
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = win32-x86
-#ARCH = linux-x86
-TARGETS = envPaths
+TARGETS = envPaths dllPath.bat
 include $(TOP)/configure/RULES.ioc


### PR DESCRIPTION
Make Makefile.win32 have the same behavior as Makefile for
ARCH=win32-x86.

Remove commented out "ARCH = linux-x86" in Makefile.win32.