### PR TITLE
Clean up st.cmd*

### DIFF
--- a/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/st_base.cmd
+++ b/iocs/pvaDriverIOC/iocBoot/iocPvaDriver/st_base.cmd
@@ -1,4 +1,4 @@
-# Must have loaded envPaths via st.cmd.linux or st.cmd.win32
+# Must have loaded envPaths via st.cmd*
 
 errlogInit(20000)
 


### PR DESCRIPTION
Generalize references to st.cmd.linux and st.cmd.win32 (which should
have been st.cmd.windows) as "st.cmd*".