### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An
 [areaDetector](https://github.com/areaDetector/areaDetector/blob/master/README.md)
 driver for importing an EPICSv4 NTNDArray via pvAccess into areaDetector.
 It does so by creating a monitor on the specified PV.  It can be used with the
-NDPluginPva to copy NDArrys from one IOC to another, but can also be used to
+NDPluginPva to copy NDArrays from one IOC to another, but can also be used to
 allow any EPICS V4 server to send NTNDArrays to the IOC.
 
 


### PR DESCRIPTION
Missing an 'a' in array