### PR TITLE
In the pvaDriverConfig function, make it possible to use a non-defaul…

### DIFF
--- a/documentation/pvaDriverDoc.html
+++ b/documentation/pvaDriverDoc.html
@@ -146,12 +146,13 @@
   <pre>int pvaDriverConfig(const char *portName, const char *pvName,
                       int maxSizeX, int maxSizeY, int dataType,
                       int maxBuffers, size_t maxMemory,
-                      int priority, int stackSize)
+                      int priority, int stackSize, int pvaQueueSize)
   </pre>
   <p>
     The pvaDriver-specific fields in this command are:</p>
   <ul>
     <li><code>pvName</code> Name of the PV to be monitored.</li>
+    <li><code>pvaQueueSize</code> The size of the queueSize parameter for the PVAccess request (optional).</li>
   </ul>
   <p>
     For details on the meaning of the other parameters to this function refer to the

--- a/pvaDriverApp/src/pvaDriver.h
+++ b/pvaDriverApp/src/pvaDriver.h
@@ -23,7 +23,7 @@ class epicsShareClass pvaDriver : public ADDriver,
 
 public:
     pvaDriver (const char *portName, const char *pvName, int maxBuffers,
-            size_t maxMemory, int priority, int stackSize);
+	       size_t maxMemory, int priority, int stackSize, const char *pvaRequest);
 
     // Overriden from ADDriver:
     asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);


### PR DESCRIPTION
…t queueSize for the PVAccess request. The default is the same as before.

See issue: https://github.com/areaDetector/pvaDriver/issues/12